### PR TITLE
Fix linkedin url

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can click the Preview link to take a look at your changes.
 <div> 
     <a href="https://instagram.com/kevilynqd" target="_blank"><img src="https://img.shields.io/badge/-Instagram-%23E4405F?style=for-the-badge&logo=instagram&logoColor=white" target="_blank"></a>
     <a href = "mailto:kevilynqd@hotmail.com"><img src="https://img.shields.io/badge/Microsoft_Outlook-0078D4?style=for-the-badge&logo=microsoft-outlook&logoColor=white" target="_blank"></a>
-    <a href="linkedin.com/in/kevilynqueirozdomingos/" target="_blank"><img src="https://img.shields.io/badge/-LinkedIn-%230077B5?style=for-the-badge&logo=linkedin&logoColor=white" target="_blank"></a>
+    <a href="https://linkedin.com/in/kevilynqueirozdomingos/" target="_blank"><img src="https://img.shields.io/badge/-LinkedIn-%230077B5?style=for-the-badge&logo=linkedin&logoColor=white" target="_blank"></a>
  
 </div>
 


### PR DESCRIPTION
The current linkedin url leads github 404 page due to lack of `https://` prefix